### PR TITLE
App decorators

### DIFF
--- a/aftman.toml
+++ b/aftman.toml
@@ -1,0 +1,7 @@
+# This file lists tools managed by Aftman, a cross-platform toolchain manager.
+# For more information, see https://github.com/LPGhatguy/aftman
+
+# To add a new tool, add an entry to this table.
+[tools]
+rojo = "rojo-rbx/rojo@7.2.1"
+# rojo = "rojo-rbx/rojo@6.2.0"

--- a/default.project.json
+++ b/default.project.json
@@ -1,5 +1,5 @@
 {
-	"name": "kip-county",
+	"name": "Silverside",
 	"globIgnorePaths": [
 		"**/package.json",
 		"**/tsconfig.json"

--- a/src/client/runtime.client.ts
+++ b/src/client/runtime.client.ts
@@ -6,6 +6,7 @@ Log.SetLogger(Logger.configure().WriteTo(Zircon.Log.Console()).EnrichWithPropert
 
 Flamework.addPaths("src/client/components");
 Flamework.addPaths("src/client/controllers");
+Flamework.addPaths("src/client/apps");
 Flamework.addPaths("src/shared/components");
 
 ZirconClient.Init();


### PR DESCRIPTION
Replaced old flamework decorator code with improved code. This simplifies the code needed to make decorators and follows the flamework docs' suggestions.

This also solves the bug of apps trying to call `nil`.